### PR TITLE
see CHANGELOG (v0.6.7)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+2022-03-29: PughLab pipeline-suite (version 0.6.7)
+- updates to annotate_germline to consider recalibrated variants as candidates
+- updates to pindel to ensure failed segments are not carried downstream
+- for pindel, removed SV tracking for WGS to improve run times (removed pindel option from mavis for wgs)
+- updates to collect_job_stats (all tools) for pbs compatibility
+- updates throughout for use with vcf2maf module (alternative to providing path)
+- updates to get_coverage.pl to split final data collection into two parts (coverage and callable bases)
+- updates to count_callable_bases.R to find callable bases for different intervals (total,target,exon,cds)
+
 2022-03-23: PughLab pipeline-suite (version 0.6.6)
 - bug fixes for msi-sensor
 - minor update for pbs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PughLab pipeline-suite (version 0.6.5)
+# PughLab pipeline-suite (version 0.6.7)
 
 ## Introduction
 This is a collection of pipelines to be used for NGS (both DNA and RNA) analyses, from alignment to variant calling.

--- a/configs/dna_pipeline_config.yaml
+++ b/configs/dna_pipeline_config.yaml
@@ -39,6 +39,7 @@ pindel_version: 0.2.5b8
 mavis_version: 2.2.5
 cpsr_version: 0.6.1
 pcgr_version: 0.9.1
+vcf2maf_version: 1.6.17 
 msi_sensor_version: msisensor-pro/1.2.0
 r_version: 3.6.1
 # tool specific parameters
@@ -163,7 +164,7 @@ haplotype_caller:
             mem: 4G
             time: '24:00:00'
 annotate:
-    vcf2maf_path: /cluster/projects/pughlab/bin/vcf2maf-1.6.17/vcf2maf.pl
+    vcf2maf_path: # /cluster/projects/pughlab/bin/vcf2maf-1.6.17/vcf2maf.pl  ## provide EITHER this or vcf2maf_version above ##
     vep_path: /cluster/tools/software/centos7/vep/98
     vep_data: /cluster/projects/pughlab/references/VEP_cache/98
     filter_vcf: /cluster/projects/pughlab/references/VEP_cache/ExAC_nonTCGA.r1.sites.hg19ToHg38.vep.vcf.gz 

--- a/configs/dna_pipeline_config_hg19.yaml
+++ b/configs/dna_pipeline_config_hg19.yaml
@@ -39,6 +39,7 @@ pindel_version: 0.2.5b8
 mavis_version: 2.2.5
 cpsr_version: 0.6.1
 pcgr_version: 0.9.1
+vcf2maf_version: 1.6.17 
 msi_sensor_version: msisensor-pro/1.2.0
 r_version: 3.6.1
 # tool specific parameters
@@ -163,7 +164,7 @@ haplotype_caller:
             mem: 4G
             time: '24:00:00'
 annotate:
-    vcf2maf_path: /cluster/projects/pughlab/bin/vcf2maf-1.6.17/vcf2maf.pl
+    vcf2maf_path: # /cluster/projects/pughlab/bin/vcf2maf-1.6.17/vcf2maf.pl  ## provide EITHER this or vcf2maf_version above ##
     vep_path: /cluster/tools/software/centos7/vep/98
     vep_data: /cluster/projects/pughlab/references/VEP_cache/98
     filter_vcf: /cluster/projects/pughlab/references/VEP_cache/ExAC_nonTCGA.r1.sites.b37TOhg19.vep.vcf.gz 

--- a/pughlab_dnaseq_pipeline.pl
+++ b/pughlab_dnaseq_pipeline.pl
@@ -561,7 +561,7 @@ sub main {
 			$hc_command = join(' ',
 				"perl $cwd/scripts/annotate_germline.pl",
 				"-o", $hc_directory,
-				"-i", join('/', $hc_directory, 'cohort','germline_variants'),
+				"-i", join('/', $hc_directory, 'cohort'),
 				"-t", $tool_config,
 				"-d", $gatk_output_yaml,
 				"-c", $args{cluster}
@@ -1658,7 +1658,9 @@ sub main {
 				$mavis_command .= " --novobreak $novobreak_directory";
 				push @depends, $novobreak_run_id;
 				}
-			if (defined($pindel_run_id)) {
+			# for wgs, because pindel is run in chunks, we miss the large SVs
+			# so won't include it here
+			if (defined($pindel_run_id) & ('wgs' ne $tool_data->{seq_type})) {
 				$mavis_command .= " --pindel $pindel_directory";
 				push @depends, $pindel_run_id;
 				}

--- a/scripts/bwa.pl
+++ b/scripts/bwa.pl
@@ -627,8 +627,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile => $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/contest.pl
+++ b/scripts/contest.pl
@@ -364,8 +364,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/count_callable_bases.R
+++ b/scripts/count_callable_bases.R
@@ -44,6 +44,7 @@ parser <- ArgumentParser();
 
 parser$add_argument('-d', '--directory', type = 'character', help = 'path to data directory');
 parser$add_argument('-p', '--project', type = 'character', help = 'project name');
+parser$add_argument('-r', '--ref_type', type = 'character', help = 'reference build (hg19 or hg38)', default = 'hg38');
 
 arguments <- parser$parse_args();
 
@@ -53,6 +54,50 @@ date <- Sys.Date();
 setwd(arguments$directory);
 
 ### MAIN ###########################################################################################
+# find regions of interest (CDS/EXON)
+if (arguments$ref_type %in% c('hg38','GRCh38')) {
+        library(TxDb.Hsapiens.UCSC.hg38.knownGene);
+        txdb <- TxDb.Hsapiens.UCSC.hg38.knownGene;
+        } else if (arguments$ref_type %in% c('hg19','GRCh37')) {
+        library(TxDb.Hsapiens.UCSC.hg19.knownGene);
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene;
+        }
+
+# organize all transcripts by GeneID
+txdb_table <- transcriptsBy(txdb, by = 'gene');
+
+# extract GeneIDs
+tx_ids <- names(txdb_table);
+
+# extract CDS info
+transcript_table <- select(
+        TxDb.Hsapiens.UCSC.hg38.knownGene,
+        keys = tx_ids,
+        columns = c('GENEID','TXNAME','TXCHROM','TXSTART','TXEND','CDSID','CDSCHROM','CDSSTART','CDSEND'),
+        keytype = 'GENEID'
+        );
+
+transcript_table <- unique(transcript_table[!is.na(transcript_table$CDSID),2:5]);
+transcript_table$CDSCHROM <- factor(transcript_table$CDSCHROM, levels = paste0('chr',c(1:22,'X','Y')));
+transcript_table <- transcript_table[order(transcript_table$CDSCHROM, transcript_table$CDSSTART),];
+
+cds.gr <- GRanges(transcript_table[!is.na(transcript_table$CDSCHROM),]);
+
+# extract EXON info
+transcript_table <- select(
+        TxDb.Hsapiens.UCSC.hg38.knownGene,
+        keys = tx_ids,
+        columns = c('GENEID','TXNAME','TXCHROM','TXSTART','TXEND','EXONID','EXONCHROM','EXONSTART','EXONEND'),
+        keytype = 'GENEID'
+        );
+
+transcript_table <- unique(transcript_table[!is.na(transcript_table$EXONID),2:5]);
+transcript_table$EXONCHROM <- factor(transcript_table$EXONCHROM, levels = paste0('chr',c(1:22,'X','Y')));
+transcript_table <- transcript_table[order(transcript_table$EXONCHROM, transcript_table$EXONSTART),];
+
+exon.gr <- GRanges(transcript_table[!is.na(transcript_table$EXONCHROM),]);
+
+
 # find results files
 cov.files <- list.files(pattern = '^CallableBases.tsv$', recursive = TRUE);
 
@@ -73,71 +118,98 @@ for (file in cov.files) {
 # determine number of callable bases
 callable.bases <- data.frame(
 	Sample = sample.list,
-	Total = NA,
-	Patient.total = NA
+	Sample.total = NA,
+	Sample.exon = NA,
+	Sample.cds = NA,
+	Patient.total = NA,
+	Patient.exon = NA,
+	Patient.cds = NA
 	);
 
 if ('TargetRegions' %in% colnames(cov.list[[1]])) {
 	callable.bases$TargetRegions <- NA;
-	callable.bases$Total.targeted <- NA;
+	callable.bases$Sample.targeted <- NA;
+	callable.bases$Sample.exon.targeted <- NA;
+	callable.bases$Sample.cds.targeted <- NA;
 	callable.bases$Patient.targeted <- NA;
+	callable.bases$Patient.exon.targeted <- NA;
+	callable.bases$Patient.cds.targeted <- NA;
 	}
 
 for (i in 1:length(cov.list)) {
-
-	# count interval length
-	cov.list[[i]]$Length <- cov.list[[i]]$end - cov.list[[i]]$start;
 
 	tmp <- cov.list[[i]];
 
 	# find samples
 	these.smps <- intersect(colnames(tmp), sample.list);
-	smp.idx <- which(callable.bases$Sample %in% these.smps);
 
-	# find total bases covered for each sample and patient
-	if (length(these.smps) == 1) {
-		total.bases <- sum(tmp[,these.smps]*tmp$Length);
-		total.patient <- total.bases;
-		} else {
-		total.bases <- apply(
-			tmp[,these.smps],
-			2,
-			function(i) { sum(i*tmp$Length) }
-			);
+	# find per-sample metrics
+	for (smp in these.smps) {
 
-		total.patient <- sum(
-			apply(tmp[,these.smps], 1, prod) * tmp$Length
-			);
+		smp.idx <- which(callable.bases$Sample == smp);
+
+		# make a genomic ranges object
+		smp.gr <- GRanges(tmp[which(tmp[,smp] == 1),c('chrom','start','end')]);
+
+		# get total callable
+		callable.bases[smp.idx,]$Sample.total <- sum(data.frame(smp.gr)$width);
+
+		# get total callable in exons
+		callable.bases[smp.idx,]$Sample.exon <- sum(data.frame(intersect(smp.gr, exon.gr))$width);
+
+		# get total callable in CDS
+		callable.bases[smp.idx,]$Sample.cds <- sum(data.frame(intersect(smp.gr, cds.gr))$width);
+
+		# get overlap with target regions too if required
+		if ('TargetRegions' %in% colnames(tmp)) {
+
+			target.gr <- GRanges(tmp[which(tmp$TargetRegions == 1),c('chrom','start','end')]);
+
+			# get total target
+			callable.bases[smp.idx,]$TargetRegions <- sum(data.frame(target.gr)$width);
+
+			target.smp.gr <- intersect(target.gr, smp.gr);
+
+			# get total target + callable
+			callable.bases[smp.idx,]$Sample.targeted <- sum(data.frame(target.smp.gr)$width);
+
+			# get total target + callable in exons
+			callable.bases[smp.idx,]$Sample.exon.targeted <- sum(data.frame(intersect(target.smp.gr, exon.gr))$width);
+
+			# get total target + callable in CDS
+			callable.bases[smp.idx,]$Sample.cds.targeted <- sum(data.frame(intersect(target.smp.gr, cds.gr))$width);
+			}
 		}
 
-	callable.bases[smp.idx,]$Total <- total.bases;
-	callable.bases[smp.idx,]$Patient.total <- total.patient;
+	# find per-patient metrics
+	# this may be T/N pairs or T/T/N sets
+	patient.idx <- which(callable.bases$Sample %in% these.smps);
 
-	# find total targeted bases covered for each sample and patient (if available)
+	# make a genomic ranges object
+	patient.gr <- GRanges(tmp[which(tmp$num == length(these.smps)),c('chrom','start','end')]);
+
+	# get total callable
+	callable.bases[patient.idx,]$Patient.total <- sum(data.frame(patient.gr)$width);
+
+	# get total callable in exons
+	callable.bases[patient.idx,]$Patient.exon <- sum(data.frame(intersect(patient.gr, exon.gr))$width);
+
+	# get total callable in CDS
+	callable.bases[patient.idx,]$Patient.cds <- sum(data.frame(intersect(patient.gr, cds.gr))$width);
+
+	# get overlap with target regions too if required
 	if ('TargetRegions' %in% colnames(tmp)) {
 
-		if (length(these.smps)  == 1) {
-			total.targeted <- sum(tmp[,these.smps]*tmp$Length*tmp$TargetRegions);
-			patient.targeted <- total.targeted;
-			} else {
-			total.patient <- sum(
-				apply(tmp[,these.smps], 1, prod) * tmp$Length
-				);
+		target.patient.gr <- intersect(target.gr, patient.gr);
 
-			total.targeted <- apply(
-				tmp[,these.smps],
-				2,
-				function(i) { sum(i*tmp$Length*tmp$TargetRegions) }
-				);
+		# get total target + callable
+		callable.bases[patient.idx,]$Patient.targeted <- sum(data.frame(target.patient.gr)$width);
 
-			patient.targeted <- sum(
-				apply(tmp[,these.smps], 1, prod) * tmp$Length * tmp$TargetRegions
-				);
-			}
+		# get total target + callable in exons
+		callable.bases[patient.idx,]$Patient.exon.targeted <- sum(data.frame(intersect(target.patient.gr, exon.gr))$width);
 
-		callable.bases[smp.idx,]$TargetRegions <- sum(tmp$TargetRegions * tmp$Length);
-		callable.bases[smp.idx,]$Total.targeted <- total.targeted;
-		callable.bases[smp.idx,]$Patient.targeted <- patient.targeted;
+		# get total target + callable in CDS
+		callable.bases[patient.idx,]$Patient.cds.targeted <- sum(data.frame(intersect(target.patient.gr, cds.gr))$width);
 		}
 	}
 

--- a/scripts/delly.pl
+++ b/scripts/delly.pl
@@ -638,8 +638,9 @@ sub pon {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(
@@ -1261,8 +1262,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/fusioncatcher.pl
+++ b/scripts/fusioncatcher.pl
@@ -347,8 +347,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids => join(',', @all_jobs),
-			outfile => $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/gatk.pl
+++ b/scripts/gatk.pl
@@ -883,8 +883,9 @@ sub main {
 
 		# collect job metrics
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/gatk_cnv.pl
+++ b/scripts/gatk_cnv.pl
@@ -1221,8 +1221,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/genotype_gvcfs.pl
+++ b/scripts/genotype_gvcfs.pl
@@ -397,6 +397,12 @@ sub main{
 	my $samtools	= 'samtools/' . $tool_data->{samtools_version};
 	my $r_version	= 'R/'. $tool_data->{r_version};
 
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
+
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{haplotype_caller}->{parameters};
 	if (!defined($parameters->{hard_filtering}->{run})) {
@@ -931,7 +937,7 @@ sub main{
 					log_dir	=> $log_directory,
 					name	=> 'run_vcf2maf_and_VEP_' . $sample,
 					cmd	=> $vcf2maf_cmd,
-					modules	=> ['perl', $samtools, 'tabix'],
+					modules => ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> $subset_run_id,
 					cpus_per_task	=> 4,
 					max_time	=> '5-00:00:00',
@@ -1049,8 +1055,9 @@ sub main{
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids => join(',', @all_jobs),
-			outfile => $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/get_sequencing_metrics.pl
+++ b/scripts/get_sequencing_metrics.pl
@@ -697,8 +697,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/haplotype_caller.pl
+++ b/scripts/haplotype_caller.pl
@@ -229,6 +229,12 @@ sub main{
 	my $samtools	= 'samtools/' . $tool_data->{samtools_version};
 	my $r_version	= 'R/' . $tool_data->{r_version};
 
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
+
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{haplotype_caller}->{parameters};
 
@@ -358,6 +364,8 @@ sub main{
 				print $log "Skipping HaplotypeCaller because this has already been completed!\n";
 				}
 
+			if ('dna' eq $data_type) { push @final_outputs, $hc_vcf; }
+
 			# if this is RNA-Seq, run filter + vcf2maf
 			if ('rna' eq $data_type) {
 
@@ -460,7 +468,7 @@ sub main{
 						log_dir	=> $log_directory,
 						name	=> 'run_vcf2maf_and_VEP_' . $sample,
 						cmd	=> $vcf2maf_cmd,
-						modules	=> ['perl', $samtools, 'tabix'],
+						modules => ['perl', $samtools, 'tabix', $vcf2maf],
 						dependencies	=> $run_id,
 						cpus_per_task	=> 4,
 						max_time	=> $parameters->{annotate}->{time},
@@ -693,8 +701,9 @@ sub main{
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/ichor_cna.pl
+++ b/scripts/ichor_cna.pl
@@ -489,8 +489,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/mavis.pl
+++ b/scripts/mavis.pl
@@ -885,8 +885,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/msi_sensor.pl
+++ b/scripts/msi_sensor.pl
@@ -508,8 +508,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/mutect.pl
+++ b/scripts/mutect.pl
@@ -553,8 +553,9 @@ sub pon {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(
@@ -697,6 +698,12 @@ sub main {
 	my $vcftools	= 'vcftools/' . $tool_data->{vcftools_version};
 	my $samtools	= 'samtools/' . $tool_data->{samtools_version};
 	my $r_version	= 'R/'. $tool_data->{r_version};
+
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
 
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{mutect}->{parameters};
@@ -949,7 +956,7 @@ sub main {
 					log_dir => $log_directory,
 					name    => 'run_vcf2maf_and_VEP_' . $sample,
 					cmd     => $vcf2maf_cmd,
-					modules => ['perl', $samtools, 'tabix'],
+					modules => ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies    => $run_id,
 					cpus_per_task	=> 4,
 					max_time        => $tool_data->{annotate}->{time},
@@ -1063,8 +1070,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/mutect2.pl
+++ b/scripts/mutect2.pl
@@ -790,8 +790,9 @@ sub pon {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(
@@ -957,6 +958,12 @@ sub main {
 	my $vcftools	= 'vcftools/' . $tool_data->{vcftools_version};
 	my $samtools	= 'samtools/' . $tool_data->{samtools_version};
 	my $r_version	= 'R/'. $tool_data->{r_version};
+
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
 
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{mutect2}->{parameters};
@@ -1395,7 +1402,7 @@ sub main {
 					log_dir => $log_directory,
 					name    => 'run_vcf2maf_and_VEP_' . $sample,
 					cmd     => $vcf2maf_cmd,
-					modules => ['perl', $samtools, 'tabix'],
+					modules => ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies    => $run_id,
 					cpus_per_task	=> 4,
 					max_time        => $tool_data->{annotate}->{time},
@@ -1508,8 +1515,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/novobreak.pl
+++ b/scripts/novobreak.pl
@@ -624,8 +624,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/panelcn_mops.pl
+++ b/scripts/panelcn_mops.pl
@@ -544,8 +544,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/pughlab_pipeline_auto_report.pl
+++ b/scripts/pughlab_pipeline_auto_report.pl
@@ -1311,8 +1311,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids => join(',', @job_ids),
-			outfile => $outfile
+			job_ids		=> join(',', @job_ids),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/rsem.pl
+++ b/scripts/rsem.pl
@@ -352,8 +352,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/run_sequenza_with_optimal_gamma.pl
+++ b/scripts/run_sequenza_with_optimal_gamma.pl
@@ -404,8 +404,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/somaticsniper.pl
+++ b/scripts/somaticsniper.pl
@@ -309,6 +309,12 @@ sub main {
 	my $vcftools	= 'vcftools/' . $tool_data->{vcftools_version};
 	my $r_version	= 'R/'. $tool_data->{r_version};
 
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
+
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{somaticsniper}->{parameters};
 
@@ -739,7 +745,7 @@ sub main {
 					log_dir => $log_directory,
 					name    => 'run_vcf2maf_and_VEP_' . $sample,
 					cmd     => $vcf2maf_cmd,
-					modules => ['perl', $samtools, 'tabix'],
+					modules => ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies    => $run_id,
 					cpus_per_task	=> 4,
 					max_time        => $tool_data->{annotate}->{time},
@@ -853,8 +859,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/star.pl
+++ b/scripts/star.pl
@@ -617,8 +617,9 @@ sub main {
 
 		# collect job metrics
 		my $collect_metrics = collect_job_stats(
-			job_ids => join(',', @all_jobs),
-			outfile => $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/star_fusion.pl
+++ b/scripts/star_fusion.pl
@@ -462,8 +462,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids => join(',', @all_jobs),
-			outfile => $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/strelka.pl
+++ b/scripts/strelka.pl
@@ -586,8 +586,9 @@ sub pon {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_pon_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_pon_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(
@@ -718,6 +719,12 @@ sub main {
 	my $vcftools	= 'vcftools/' . $tool_data->{vcftools_version};
 	my $samtools	= 'samtools/' . $tool_data->{samtools_version};
 	my $r_version	= 'R/' . $tool_data->{r_version};
+
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
 
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{strelka}->{parameters};
@@ -1085,7 +1092,7 @@ sub main {
 					log_dir	=> $log_directory,
 					name	=> 'run_vcf2maf_and_VEP_' . $sample,
 					cmd	=> $vcf2maf_cmd,
-					modules	=> ['perl', $samtools, 'tabix'],
+					modules	=> ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> $filter_run_id,
 					cpus_per_task	=> 4,
 					max_time	=> $tool_data->{annotate}->{time},
@@ -1195,8 +1202,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/svict.pl
+++ b/scripts/svict.pl
@@ -315,8 +315,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/utilities.pl
+++ b/scripts/utilities.pl
@@ -291,9 +291,9 @@ sub write_script {
 
 	my @modules_list;
 	for (my $i=0; $i < scalar (@{$args{modules}}); $i++) {
-		unless('' eq $args{modules}->[$i]) {
-			$modules_list[$i] = "module load $args{modules}->[$i]";
-			}
+		next if (!defined($args{modules}->[$i]));
+		next if ('' eq $args{modules}->[$i]);
+		$modules_list[$i] = "module load $args{modules}->[$i]";
 		}
 
 	my $modules_to_load = join(";\n", @modules_list);
@@ -686,8 +686,12 @@ sub get_vcf2maf_command {
 		$ref_type = $args{ref_type};
 		}
 
-	my $maf_command = join(' ',
-		'perl', $args{vcf2maf},
+	my $maf_command = 'vcf2maf.pl';
+	if (defined($args{vcf2maf})) {
+		$maf_command = "perl $args{vcf2maf}"; 
+		}
+
+	$maf_command .= ' ' . join(' ',
 		'--species homo_sapiens',
 		'--ncbi-build', $ref_type,
 		'--ref-fasta', $args{reference},

--- a/scripts/vardict.pl
+++ b/scripts/vardict.pl
@@ -258,6 +258,12 @@ sub main {
 	my $gatk	= 'gatk/' . $tool_data->{gatk_version};
 	my $r_version	= 'R/' . $tool_data->{r_version};
 
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
+
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{vardict}->{parameters};
 
@@ -621,7 +627,7 @@ sub main {
 					log_dir	=> $log_directory,
 					name	=> 'run_vcf2maf_and_VEP_' . $sample,
 					cmd	=> $vcf2maf_cmd,
-					modules	=> ['perl', $samtools, 'tabix'],
+					modules	=> ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> $run_id,
 					cpus_per_task	=> 4,
 					max_time	=> $tool_data->{annotate}->{time},
@@ -993,7 +999,7 @@ sub main {
 					log_dir	=> $log_directory,
 					name	=> 'run_vcf2maf_and_VEP_' . $sample,
 					cmd	=> $vcf2maf_cmd,
-					modules	=> ['perl', $samtools, 'tabix'],
+					modules	=> ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> $run_id,
 					cpus_per_task	=> 4,
 					max_time	=> $tool_data->{annotate}->{time},
@@ -1106,8 +1112,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/vardict_wgs.pl
+++ b/scripts/vardict_wgs.pl
@@ -363,6 +363,12 @@ sub main {
 	my $gatk	= 'gatk/' . $tool_data->{gatk_version};
 	my $r_version	= 'R/' . $tool_data->{r_version};
 
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
+
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{vardict}->{parameters};
 
@@ -803,7 +809,8 @@ sub main {
 					tmp_dir		=> $tmp_directory,
 					output_stem	=> $output_stem,
 					intervals	=> $intervals_bed,
-					modifier	=> $task_array_modifier
+					modifier	=> $task_array_modifier,
+					java_mem	=> $parameters->{vardict}->{java_mem} 
 					);
 
 				# check if this should be run
@@ -1004,7 +1011,7 @@ sub main {
 					log_dir	=> $log_directory,
 					name	=> 'run_vcf2maf_and_VEP_' . $sample,
 					cmd	=> $vcf2maf_cmd,
-					modules	=> ['perl', $samtools, 'tabix'],
+					modules	=> ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> $run_id,
 					cpus_per_task	=> 4,
 					max_time	=> $tool_data->{annotate}->{time},
@@ -1321,7 +1328,8 @@ sub main {
 					tmp_dir		=> $tmp_directory,
 					output_stem	=> $output_stem,
 					intervals	=> $intervals_bed,
-					modifier	=> $task_array_modifier
+					modifier	=> $task_array_modifier,
+					java_mem	=> $parameters->{vardict}->{java_mem} 
 					);
 
 				# check if this should be run
@@ -1495,7 +1503,7 @@ sub main {
 					log_dir	=> $log_directory,
 					name	=> 'run_vcf2maf_and_VEP_' . $sample,
 					cmd	=> $vcf2maf_cmd,
-					modules	=> ['perl', $samtools, 'tabix'],
+					modules	=> ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> $run_id,
 					cpus_per_task	=> 4,
 					max_time	=> $tool_data->{annotate}->{time},
@@ -1609,8 +1617,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(

--- a/scripts/varscan.pl
+++ b/scripts/varscan.pl
@@ -326,6 +326,12 @@ sub main {
 	my $gatk	= 'gatk/' . $tool_data->{gatk_version};
 	my $r_version	= 'R/' . $tool_data->{r_version};
 
+	my $vcf2maf = undef;
+	if (defined($tool_data->{vcf2maf_version})) {
+		$vcf2maf = 'vcf2maf/' . $tool_data->{vcf2maf_version};
+		$tool_data->{annotate}->{vcf2maf_path} = undef;
+		}
+
 	# get user-specified tool parameters
 	my $parameters = $tool_data->{varscan}->{parameters};
 
@@ -1030,7 +1036,7 @@ sub main {
 					log_dir	=> $log_directory,
 					name	=> 'run_vcf2maf_and_VEP_' . $sample,
 					cmd	=> $vcf2maf_cmd,
-					modules	=> ['perl', $samtools, 'tabix'],
+					modules	=> ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> $run_id,
 					cpus_per_task	=> 4,
 					max_time	=> $tool_data->{annotate}->{time},
@@ -1614,7 +1620,7 @@ sub main {
 					log_dir => $log_directory,
 					name    => 'run_vcf2maf_and_VEP_' . $sample,
 					cmd     => $vcf2maf_cmd,
-					modules => ['perl', $samtools, 'tabix'],
+					modules => ['perl', $samtools, 'tabix', $vcf2maf],
 					dependencies	=> join(':', @dependencies),
 					cpus_per_task	=> 4,
 					max_time	=> $tool_data->{annotate}->{time},
@@ -1727,8 +1733,9 @@ sub main {
 
 		# collect job stats
 		my $collect_metrics = collect_job_stats(
-			job_ids	=> join(',', @all_jobs),
-			outfile	=> $outfile
+			job_ids		=> join(',', @all_jobs),
+			outfile		=> $outfile,
+			hpc_driver	=> $args{hpc_driver}
 			);
 
 		$run_script = write_script(


### PR DESCRIPTION
2022-03-29: PughLab pipeline-suite (version 0.6.7)
- updates to annotate_germline to consider recalibrated variants as candidates
- updates to pindel to ensure failed segments are not carried downstream
- for pindel, removed SV tracking for WGS to improve run times (removed pindel option from mavis for wgs)
- updates to collect_job_stats (all tools) for pbs compatibility
- updates throughout for use with vcf2maf module (alternative to providing path)
- updates to get_coverage.pl to split final data collection into two parts (coverage and callable bases)
- updates to count_callable_bases.R to find callable bases for different intervals (total,target,exon,cds)