### PR TITLE
Dev

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,19 @@
+2024-03-27: PughLab pipeline-suite (version 0.9.8);
+- updated bwameth version/path (now available as a module on H4H)
+- minor updates to example config files:
+	- added manta step (removed from strelka) to dna pipeline config
+	- added default version for bwa_meth + increased some mem/time parameters
+- minor updates throughout scripts:
+	- annotate_germline.pl (added sort steps to prevent out of order errors in vcf2maf)
+	- collect_snv_output.R (added filtering for germline variants to remove duplicates)
+	- bwa.pl (bwameth version/path)
+	- mutect2.pl (removed non-existant file from cleanup)
+	- novobreak.pl (changed n_cpu to n_cpus for consistency)
+	- methyldackel.pl (mbias output file names)
+	- strelka.pl (code cleanup; removed manta code)
+	- trim_adapters.pl (fixed output file names for trim_galore)
+- minor updates to report functions (added error checking and conditions)
+
 2024-03-06: PughLab pipeline-suite (version 0.9.7);
 - NEW: initial add of methyldackel.pl to run mbias and extract functions on EM-Seq
 - pughlab_fragmentomics_pipeline.pl and fragmentomics_pipeline_config.yaml: added option to specify either number of reads or overall scale factor for downsample step

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PughLab pipeline-suite (version 0.9.7)
+# PughLab pipeline-suite (version 0.9.8)
 
 ## Introduction
 This is a collection of pipelines to be used for NGS (DNA, including WGS, WXS and TS, RNA-Seq and EM-Seq) analyses, from alignment to variant calling.

--- a/configs/dna_pipeline_config.yaml
+++ b/configs/dna_pipeline_config.yaml
@@ -224,9 +224,6 @@ strelka:
         strelka:
             mem: 8G
             time: '24:00:00'
-        manta:
-            mem: 8G
-            time: '24:00:00'
         filter:
             mem: 2G
             time: '12:00:00'
@@ -330,7 +327,7 @@ gatk_cnv:
             mem: 4G
             time: '24:00:00'
 manta:
-    run: N
+    run: Y
     parameters:
         manta:
             mem: 8G
@@ -357,7 +354,7 @@ novobreak:
         novobreak:
             mem: 40G
             time: '24:00:00'
-            n_cpu: 10
+            n_cpus: 10
         group_reads:
             mem: 40G
             time: '24:00:00'

--- a/configs/dna_pipeline_config_hg19.yaml
+++ b/configs/dna_pipeline_config_hg19.yaml
@@ -224,9 +224,6 @@ strelka:
         strelka:
             mem: 8G
             time: '24:00:00'
-        manta:
-            mem: 8G
-            time: '24:00:00'
         filter:
             mem: 2G
             time: '12:00:00'
@@ -329,7 +326,7 @@ gatk_cnv:
             mem: 4G
             time: '24:00:00'
 manta:
-    run: N
+    run: Y
     parameters:
         manta:
             mem: 8G
@@ -356,7 +353,7 @@ novobreak:
         novobreak:
             mem: 40G
             time: '24:00:00'
-            n_cpu: 10
+            n_cpus: 10
         group_reads:
             mem: 40G
             time: '24:00:00'

--- a/configs/emseq_pipeline_config.yaml
+++ b/configs/emseq_pipeline_config.yaml
@@ -12,9 +12,10 @@ ref_type: hg38 # one of hg38, hg19, GRCh37 or GRCh38 (minimal testing with GRCh3
 reference: /cluster/tools/data/genomes/human/hg38/iGenomes/Sequence/WholeGenomeFasta/genome.fa
 baits_bed: 
 targets_bed:
+gnomad: /cluster/projects/pughlab/references/ExAC/af-only-gnomad.hg38.vcf.gz 
 # tool versions
-bwa_meth_version: # for use with module load bwa_meth/version (if available)
-bwa_meth_path: /cluster/projects/pughlab/bin/bwa_meth/v0.2.7/bwameth.py
+bwa_meth_version: 0.2.7 # for use with module load bwa_meth/version (if available)
+bwa_meth_path: #/cluster/projects/pughlab/bin/bwa_meth/v0.2.7/bwameth.py
 mark_nonconverted_path: /cluster/projects/pughlab/bin/mark-nonconverted-reads/mark-nonconverted-reads.py
 bwa_version: 0.7.15
 samtools_version: 1.10
@@ -22,6 +23,7 @@ methyldackel_version: 0.6.1
 python3_version: 3.10.9
 picard_version: 2.10.9
 sambamba_version: 0.7.0 
+gatk_cnv_version: 4.1.8.1 # for qc tools
 r_version: 4.1.0
 # tool specific parameters
 trim_adapters:
@@ -43,21 +45,21 @@ bwa:
     parameters:
         bwa:
             n_cpus:
-                normal: 4
-                tumour: 4
+                normal: 8
+                tumour: 8
             mem:
-                normal: 8G
-                tumour: 16G
+                normal: 16G
+                tumour: 20G
             time:
-                normal: '12:00:00'
-                tumour: '24:00:00'
+                normal: '5-00:00:00'
+                tumour: '5-00:00:00'
         sort:
             mem:
-                normal: 2G
-                tumour: 2G
+                normal: 4G
+                tumour: 4G
             time:
-                normal: '12:00:00'
-                tumour: '24:00:00'
+                normal: '24:00:00'
+                tumour: '48:00:00'
         index:
             mem:
                 normal: 2G
@@ -69,15 +71,15 @@ bwa:
             mem: 12G
             time: '48:00:00'
         merge:
-            tool: 'picard' # or sambamba
+            tool: 'sambamba'
             mark_dup: Y
             n_cpus: 1 # or more for sambamba
             java_mem:
-                normal: 3g
-                tumour: 3g
+                normal: 7g
+                tumour: 11g
             mem:
-                normal: 4G
-                tumour: 4G
+                normal: 8G
+                tumour: 12G
             time:
                 normal: '48:00:00'
                 tumour: '48:00:00'
@@ -92,7 +94,7 @@ methyldackel:
     run: Y
     parameters:
         mbias:
-            mem: 4G
+            mem: 2G
             time: '24:00:00'
         extract:
             mem: 4G

--- a/scripts/bwa.pl
+++ b/scripts/bwa.pl
@@ -380,11 +380,11 @@ sub main {
 	my $bwameth_version;
 	$bwameth_path = 'bwameth.py';
 	if (defined($tool_data->{bwa_meth_version})) {
-		$bwameth_version = 'bwa_meth/' . $tool_data->{bwa_meth};
+		$bwameth_version = 'bwa_meth/' . $tool_data->{bwa_meth_version};
 		} elsif (defined($tool_data->{bwa_meth_path})) {
 		$bwameth_path = $tool_data->{bwa_meth_path};
 		} else {
-		$bwameth_version = 'bwa_meth/git';
+		$bwameth_version = 'bwa_meth';
 		}
 
 	# indicate type of sequencing (WGS/WXS or EMSeq (WGS or targeted))

--- a/scripts/collect_snv_output.R
+++ b/scripts/collect_snv_output.R
@@ -93,12 +93,22 @@ for (i in 1:length(maf.files)) {
 
 	# read in data
 	if (is.germline) {
+		# required if there are few variants (and all ref or alt alleles = T [sets to TRUE] if left alone)
 		tmp <- read.delim(file, comment.char = "#", colClasses = maf.classes);
 		} else {
 		tmp <- read.delim(file, comment.char = "#", as.is = TRUE);
 		}
 
 	## do some filtering
+	if (is.germline) {
+		if (any(tmp$Tumor_Seq_Allele2 == '*')) {
+			tmp <- tmp[which(tmp$Tumor_Seq_Allele2 != '*'),];
+			}
+		tmp <- tmp[order(tmp$Chromosome, tmp$Start_Position, tmp$End_Position, -tmp$CPSR_PATHOGENICITY_SCORE),];
+		non.dup.idx <- !duplicated(tmp[,c('Chromosome', 'Start_Position', 'End_Position','Tumor_Seq_Allele2'),]);
+		tmp <- tmp[non.dup.idx,];
+		}
+
 	# for some reason WGS:SomaticSniper output has FILTER = '.'
 	if (!(is.wgs & grepl('SomaticSniper', getwd()))) {
 		tmp <- tmp[which(tmp$FILTER == 'PASS'),];

--- a/scripts/methyldackel.pl
+++ b/scripts/methyldackel.pl
@@ -242,9 +242,7 @@ sub main {
 				output_stem	=> join('/', $mbias_directory, $sample . '_mbias')
 				);
 
-		#	$cleanup_cmd .= "\nrm -rf " . join('/', $sample_directory, 'workspace');
-
-			my $mbias_output = join('/', $patient_directory, $sample . '_methyldackel.COMPLETE');
+			my $mbias_output = join('/', $mbias_directory, $sample . '_mbias.COMPLETE');
 	
 			$mbias_command .= "\n\n" . join(' ',
 				'echo methyldackel mbias complete',

--- a/scripts/mutect2.pl
+++ b/scripts/mutect2.pl
@@ -1355,7 +1355,6 @@ sub main {
 				}
 
 			$cleanup_cmd .= "\n  rm $merged_output";
-			$cleanup_cmd .= "\n  rm $merged_output.idx";
 
 			# filter results
 			my $filtered_stem = join('/', $sample_directory, $sample . '_MuTect2_filtered');

--- a/scripts/novobreak.pl
+++ b/scripts/novobreak.pl
@@ -446,7 +446,7 @@ sub main {
 					modules	=> [$samtools, $novobreak, 'perl'],
 					max_time	=> $parameters->{novobreak}->{time},
 					mem		=> $parameters->{novobreak}->{mem},
-					cpus_per_task	=> $parameters->{novobreak}->{n_cpu},
+					cpus_per_task	=> $parameters->{novobreak}->{n_cpus},
 					hpc_driver	=> $args{hpc_driver},
 					extra_args	=> [$hpc_group]
 					);

--- a/scripts/pughlab_pipeline_auto_report.pl
+++ b/scripts/pughlab_pipeline_auto_report.pl
@@ -77,7 +77,7 @@ sub main {
 
 	print $log "---\n";
 	print $log "Running Summarize Results Pipeline...\n";
-	print $log "\n  Tool config used: $args{config}";
+	print $log "\n  Tool config used: $args{tool_config}";
 	print $log "\n  Output directory: $output_directory";
 	print $log "\n---\n";
 
@@ -1677,7 +1677,7 @@ sub main {
 		$methods_command = "perl $cwd/report/write_targetseq_methods.pl";
 		}
 
-	$methods_command .= " -t $args{config} -d $plot_directory";
+	$methods_command .= " -t $args{tool_config} -d $plot_directory";
 
 	# run command
 	print $log "Submitting job to write methods...\n";

--- a/scripts/report/apply_cosmic_mutation_signatures.R
+++ b/scripts/report/apply_cosmic_mutation_signatures.R
@@ -176,16 +176,16 @@ assigned.sigs <- list();
 
 for (smp in all.samples) {
 
+	if (nrow(snv.data[which(snv.data$Sample == smp),]) < 50) {
+		assigned.sigs[[smp]]$weights <- rep(NA, ncol(signatures.to.apply));
+		next;
+		}
+
 	if (!dir.exists(smp)) {
 		dir.create(smp);
 		}
 
 	setwd(smp);
-
-	if (nrow(snv.data[which(snv.data$Sample == smp),]) < 50) {
-		assigned.sigs[[smp]]$weights <- rep(NA, ncol(signatures.to.apply));
-		next;
-		}
 
 	assigned.sigs[[smp]] <- whichSignatures(
 		tumor.ref = sigs.input,

--- a/scripts/report/get_hrdetect_signatures.R
+++ b/scripts/report/get_hrdetect_signatures.R
@@ -101,7 +101,7 @@ if (length(vcf.files) == 0) {
 	stop('ERROR: No VCFs found in input directory, please provide path to VCF files.');
 	}
 
-all.samples <- as.character(sapply(vcf.files,function(i) { unlist(strsplit(basename(i),'_'))[1] } ));
+snv.samples <- as.character(sapply(vcf.files,function(i) { unlist(strsplit(basename(i),'_'))[1] } ));
 
 # get mutation data
 if (is.null(arguments$sv)) {
@@ -110,11 +110,18 @@ if (is.null(arguments$sv)) {
 	sv.data <- read.delim(arguments$sv, stringsAsFactors = FALSE);
 	}
 
+if (any(sv.data$protocol == 'transcriptome')) {
+	sv.data$library <- gsub('-rna','', sv.data$library);
+	}
+sv.samples <- unique(sv.data$library);
+
 if (is.null(arguments$cnv)) {
 	stop('ERROR: No CNA segments provided, please provide path to CNA segment file from Sequenza.');
 	} else {
 	seg.data <- read.delim(arguments$cnv, stringsAsFactors = FALSE);
 	}
+
+cna.samples <- unique(seg.data$Sample);
 
 # create (if necessary) and move to output directory
 if (!dir.exists(arguments$output)) {
@@ -122,6 +129,10 @@ if (!dir.exists(arguments$output)) {
 	}
 
 setwd(arguments$output);
+
+# get list of overlapping samples (snv/indel + sv + cnv)
+all.samples <- intersect(
+	snv.samples, intersect(sv.samples, cna.samples));
 
 ### FORMAT DATA ####################################################################################
 # format CNV data

--- a/scripts/report/plot_sv_summary.R
+++ b/scripts/report/plot_sv_summary.R
@@ -470,7 +470,9 @@ for (smp in tumour.samples) {
 		Evidence = sapply(smp.data$tools, function(i) { length(unlist(strsplit(i,';'))) } )
 		);
 
-	plot.data[which(plot.data$Evidence == 1),]$Evidence <- 0.5;
+	if (any(plot.data$Evidence == 1)) {
+		plot.data[which(plot.data$Evidence == 1),]$Evidence <- 0.5;
+		}
 	if (any(smp.data$Fusion == 'None--None')) {
 		plot.data[which(smp.data$Fusion == 'None--None'),]$Evidence <- 0.5;
 		}

--- a/scripts/strelka.pl
+++ b/scripts/strelka.pl
@@ -38,53 +38,6 @@ our ($reference, $intervals, $seq_type, $pon) = undef;
 #	--dry_run indicates that this is a dry run
 
 ### DEFINE SUBROUTINES #############################################################################
-# format command to run Manta
-sub get_manta_command {
-	my %args = (
-		tumour		=> undef,
-		normal		=> undef,
-		output_dir	=> undef,
-		intervals	=> undef,
-		tmp_dir		=> undef,
-		@_
-		);
-
-	my $manta_cmd = 'configManta.py ';
-	
-	if ('targeted' eq $seq_type) {
-		$manta_cmd = join("\n",
-			'DIRNAME=$(which configManta.py | xargs dirname)',
-			'cp $DIRNAME/configManta.py.ini ' . $args{output_dir},
-			"sed -i 's/minEdgeObservations = 3/minEdgeObservations = 2/' $args{output_dir}/configManta.py.ini",
-			"sed -i 's/minCandidateSpanningCount = 3/minCandidateSpanningCount = 2/' $args{output_dir}/configManta.py.ini",
-			"\n" . "configManta.py --config $args{output_dir}/configManta.py.ini "
-			);
-		}
-
-	if (defined($args{normal})) {
-		$manta_cmd .= join(' ',
-			'--normalBam', $args{normal},
-			'--tumorBam', $args{tumour},
-			'--referenceFasta', $reference,
-			'--runDir', $args{output_dir}
-			);
-		} else {
-		$manta_cmd .= join(' ',
-			'--tumorBam', $args{tumour},
-			'--referenceFasta', $reference,
-			'--runDir', $args{output_dir}
-			);
-		}
-
-	if (('exome' eq $seq_type) || ('targeted' eq $seq_type)) {
-		$manta_cmd .= " --exome --callRegions $args{intervals}";
-		} elsif ( ('rna' eq $seq_type) && (!defined($args{normal})) ) {
-		$manta_cmd .= " --rna";
-		}
-
-	return($manta_cmd);
-	}
-
 # format command to run Strelka Somatic Workflow
 sub get_strelka_somatic_command {
 	my %args = (

--- a/scripts/trim_adapters.pl
+++ b/scripts/trim_adapters.pl
@@ -218,10 +218,10 @@ sub main {
 							);
 
 						$new_r1 = join('/', $output_directory, basename($r1));
-						$new_r1 =~ s/.fastq.gz/_trimmed.fastq.gz/;
+						$new_r1 =~ s/.fastq.gz/_val_1.fq.gz/;
 
 						$new_r2 = join('/', $output_directory, basename($r2));
-						$new_r2 =~ s/.fastq.gz/_trimmed.fastq.gz/;
+						$new_r2 =~ s/.fastq.gz/_val_2.fq.gz/;
 
 						} else {
 


### PR DESCRIPTION
2024-03-27: PughLab pipeline-suite (version 0.9.8);
- updated bwameth version/path (now available as a module on H4H)
- minor updates to example config files:
        - added manta step (removed from strelka) to dna pipeline config
        - added default version for bwa_meth + increased some mem/time parameters
- minor updates throughout scripts:
        - annotate_germline.pl (added sort steps to prevent out of order errors in vcf2maf)
        - collect_snv_output.R (added filtering for germline variants to remove duplicates)
        - bwa.pl (bwameth version/path)
        - mutect2.pl (removed non-existant file from cleanup)
        - novobreak.pl (changed n_cpu to n_cpus for consistency)
        - methyldackel.pl (mbias output file names)
        - strelka.pl (code cleanup; removed manta code)
        - trim_adapters.pl (fixed output file names for trim_galore)
- minor updates to report functions (added error checking and conditions)